### PR TITLE
Add Windows platform support

### DIFF
--- a/.github/workflows/ci-build.yaml
+++ b/.github/workflows/ci-build.yaml
@@ -3,7 +3,7 @@ name: CI build
 on: [push]
 
 jobs:
-  build:
+  build-unix:
     runs-on: macos-15
     steps:
       - name: Install dependencies
@@ -27,7 +27,59 @@ jobs:
       - name: Upload artifacts
         uses: actions/upload-artifact@v4
         with:
-          name: package
+          name: package-unix
           path: |
             include
             lib
+
+  build-windows:
+    runs-on: windows-latest
+    steps:
+      - name: Install Conan
+        run: pip install conan
+
+      - name: Set up Conan
+        run: conan profile detect
+
+      - name: Checkout source
+        uses: actions/checkout@v4
+
+      - name: Build library
+        shell: bash
+        run: |
+          ./build.sh
+
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: package-windows
+          path: |
+            include
+            lib
+
+  package:
+    needs: [build-unix, build-windows]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download Unix artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: package-unix
+          path: output
+
+      - name: Download Windows artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: package-windows
+          path: output
+
+      - name: Create combined package
+        run: |
+          cd output
+          zip -r ../package.zip include lib
+
+      - name: Upload combined package
+        uses: actions/upload-artifact@v4
+        with:
+          name: package
+          path: package.zip

--- a/build.sh
+++ b/build.sh
@@ -43,16 +43,24 @@ buildLinux() {
   scripts/build-library.sh linux-x86 linux/x86
 }
 
+buildWindows() {
+  scripts/build-library.sh windows-x64 windows/x64
+}
+
 set -e
 
 cd "$(dirname "$0")"
 
 rm -rf lib include
 
-buildiOS
-buildAndroid
-buildMacOS
-buildLinux
+if [[ "$OSTYPE" == "msys" || "$OSTYPE" == "cygwin" || "$OS" == "Windows_NT" ]]; then
+  buildWindows
+else
+  buildiOS
+  buildAndroid
+  buildMacOS
+  buildLinux
+fi
 
 if [[ $1 == "--package" ]]; then
   zip -r package.zip include lib

--- a/profiles/windows-arm64.profile
+++ b/profiles/windows-arm64.profile
@@ -1,0 +1,8 @@
+include(default)
+
+[settings]
+os=Windows
+arch=armv8
+compiler=msvc
+compiler.version=194
+compiler.runtime=static

--- a/profiles/windows-x64.profile
+++ b/profiles/windows-x64.profile
@@ -1,0 +1,8 @@
+include(default)
+
+[settings]
+os=Windows
+arch=x86_64
+compiler=msvc
+compiler.version=194
+compiler.runtime=static

--- a/scripts/build-library.sh
+++ b/scripts/build-library.sh
@@ -43,15 +43,18 @@ else
   exit 1
 fi
 
-# Rename all libuv_a.a to libuv.a
-# Older versions of libuv used libuv_a.a. This makes the script compatible with both
-# and dependent apps can use the new name.
-for file in "$OUTPUT_LIB_DIR"/libuv_a.a; do
+# Rename libuv_a to libuv for consistent naming.
+# Handles both Unix (.a) and Windows (.lib) static libraries.
+for file in "$OUTPUT_LIB_DIR"/libuv_a.a "$OUTPUT_LIB_DIR"/uv_a.lib; do
   if [[ -f "$file" ]]; then
     mv "$file" "${file/_a/}"
   fi
 done
-find "$OUTPUT_LIB_DIR" -type f -name "*.cmake" -exec sed -i '' 's/uv_a/uv/g' {} +
+if [[ "$OSTYPE" == "darwin"* ]]; then
+  find "$OUTPUT_LIB_DIR" -type f -name "*.cmake" -exec sed -i '' 's/uv_a/uv/g' {} +
+else
+  find "$OUTPUT_LIB_DIR" -type f -name "*.cmake" -exec sed -i 's/uv_a/uv/g' {} +
+fi
 
 # Clean up
 rm -rf ${BUILD_DIR}


### PR DESCRIPTION
## Summary
- Add Conan profiles for windows-x64 and windows-arm64 (MSVC, static CRT)
- Add `buildWindows()` function to `build.sh` with Windows environment detection
- Fix `sed -i` portability (BSD vs GNU) in `build-library.sh`
- Handle Windows `.lib` renaming (`uv_a.lib` -> `uv.lib`) alongside Unix `.a`
- Update CI to build Windows on `windows-latest` runner and combine artifacts

## Test plan
- [ ] CI builds successfully on the `feature/windows-support` branch
- [ ] Windows job produces correct static `.lib` files
- [ ] Combined package artifact contains both Unix and Windows libraries

🤖 Generated with [Claude Code](https://claude.com/claude-code)